### PR TITLE
fix: use this crate feature flag and fix compilation

### DIFF
--- a/tracy-gizmos/src/lib.rs
+++ b/tracy-gizmos/src/lib.rs
@@ -540,7 +540,7 @@ impl Drop for TracyCapture {
 #[macro_export]
 #[cfg(feature = "unstable-function-names")]
 macro_rules! create_function_name_for_zone {
-		($FUNCTION: ident) => {
+	($FUNCTION: ident) => {
 		struct X;
 		const $FUNCTION: &'static [u8] = {
 			&$crate::details::get_fn_name_from_nested_type::<X>()
@@ -551,9 +551,9 @@ macro_rules! create_function_name_for_zone {
 #[macro_export]
 #[cfg(not(feature = "unstable-function-names"))]
 macro_rules! create_function_name_for_zone {
-		($FUNCTION: ident) => {
+	($FUNCTION: ident) => {
 		const $FUNCTION: &'static [u8] = b"<unavailable>\0";
-		};
+	};
 }
 
 /// Instruments the current scope with a profiling zone.


### PR DESCRIPTION
Fix #1 

this fixes the following lint error when using this crate with stable Rust:
```
warning: unexpected `cfg` condition value: `unstable-function-names`
  --> examples/examples/usage.rs:27:2
   |
27 |     zone!("main");
   |     ^^^^^^^^^^^^^
   |
   = note: expected values for `feature` are: `default` and `instrumented`
   = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `$crate::zone` crate for guidance on how handle this unexpected cfg
   = help: the macro `$crate::zone` may come from an old version of the `tracy_gizmos` crate, try updating your dependency with `cargo update -p tracy_gizmos`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
   = note: this warning originates in the macro `$crate::zone` which comes from the expansion of the macro `zone` (in Nightly builds, run with -Z macro-backtrace for more info)
```