### PR TITLE
Add intern plot

### DIFF
--- a/tracy-gizmos/src/lib.rs
+++ b/tracy-gizmos/src/lib.rs
@@ -823,7 +823,7 @@ impl Drop for Frame {
 		// frame! macro, which ensures that contained pointer is
 		// correct.
 		unsafe {
-			sys::___tracy_emit_frame_mark_end(self.0);
+			sys::___tracy_emit_frame_mark_end(self.0.cast());
 		}
 	}
 }
@@ -947,7 +947,7 @@ pub mod details {
 
 	#[inline(always)]
 	pub unsafe fn discontinuous_frame(name: *const i8) -> Frame {
-		sys::___tracy_emit_frame_mark_start(name);
+		sys::___tracy_emit_frame_mark_start(name.cast());
 		Frame(name)
 	}
 

--- a/tracy-gizmos/src/lib.rs
+++ b/tracy-gizmos/src/lib.rs
@@ -536,6 +536,26 @@ impl Drop for TracyCapture {
 	}
 }
 
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "unstable-function-names")]
+macro_rules! create_function_name_for_zone {
+	($FUNCTION: ident) => {
+		struct X;
+		const $FUNCTION: &'static [u8] = {
+			&$crate::details::get_fn_name_from_nested_type::<X>()
+		};
+	}
+}
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "unstable-function-names"))]
+macro_rules! create_function_name_for_zone {
+	($FUNCTION: ident) => {
+		const $FUNCTION: &'static [u8] = b"<unavailable>\0";
+	};
+}
+
 /// Instruments the current scope with a profiling zone.
 ///
 /// A zone represents the lifetime of a special on-stack profiler
@@ -647,16 +667,7 @@ macro_rules! zone {
 
 	(@loc $name:literal, $color: expr) => {{
 		// This is an implementation detail and can be changed at any moment.
-
-		#[cfg(feature = "unstable-function-names")]
-		struct X;
-		#[cfg(feature = "unstable-function-names")]
-		const FUNCTION: &'static [u8] = {
-			&$crate::details::get_fn_name_from_nested_type::<X>()
-		};
-
-		#[cfg(not(feature = "unstable-function-names"))]
-		const FUNCTION: &'static [u8] = b"<unavailable>\0";
+		$crate::create_function_name_for_zone!(FUNCTION);
 
 		// SAFETY: All passed data is created here and is correct.
 		static LOC: $crate::ZoneLocation = unsafe {


### PR DESCRIPTION
This is required to support non-literal plot names, such as per-consumer
reservations tracing.

e.g. initialization:
```
tracy_plot: Plot::with_config(
    intern_plot_name(&name),
    PlotConfig { format: PlotFormat::Memory, style: PlotStyle::Staircase, ..Default::default() },
),
```

e.g. usage:
```
tracy_gizmos::plot!(consumer_state.tracy_plot, consumer_state.memory_usage as i64);
```

